### PR TITLE
ROE-2234 Add InternalUserInterceptor from api-security-java to only a…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <private-api-sdk-java.version>2.0.256</private-api-sdk-java.version>
     <encoder.version>1.2.3</encoder.version>
     <rest-service-common-library-version>0.0.8</rest-service-common-library-version>
+    <api-security-java.version>0.4.1</api-security-java.version>
   </properties>
   <profiles>
     <profile>
@@ -100,6 +101,11 @@
       <groupId>org.owasp.encoder</groupId>
       <artifactId>encoder</artifactId>
       <version>${encoder.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>uk.gov.companieshouse</groupId>
+      <artifactId>api-security-java</artifactId>
+      <version>${api-security-java.version}</version>
     </dependency>
 
     <!-- test dependencies -->

--- a/src/main/java/uk/gov/companieshouse/authcodenotification/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/authcodenotification/config/InterceptorConfig.java
@@ -12,8 +12,8 @@ import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 @ComponentScan("uk.gov.companieshouse.api.interceptor")
 public class InterceptorConfig implements WebMvcConfigurer {
 
-    static final String ALL_PATHS = "/**";
-    static final String HEALTH_CHECK_PATH = "/auth-code-notification/healthcheck";
+    private static final String ALL_PATHS = "/**";
+    private static final String HEALTH_CHECK_PATH = "/**/healthcheck";
 
     @Autowired
     private InternalUserInterceptor internalUserInterceptor;

--- a/src/main/java/uk/gov/companieshouse/authcodenotification/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/authcodenotification/config/InterceptorConfig.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.authcodenotification.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.lang.NonNull;
@@ -13,7 +14,14 @@ import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 public class InterceptorConfig implements WebMvcConfigurer {
 
     private static final String ALL_PATHS = "/**";
-    private static final String HEALTH_CHECK_PATH = "/**/healthcheck";
+
+    // see application.properties
+    @Value("${management.endpoints.web.base-path}")
+    private String managementBasePath;
+
+    // see application.properties
+    @Value("${management.endpoints.web.path-mapping.health}")
+    private String healthCheckPathSuffix;
 
     @Autowired
     private InternalUserInterceptor internalUserInterceptor;
@@ -27,6 +35,6 @@ public class InterceptorConfig implements WebMvcConfigurer {
     public void addInterceptors(@NonNull InterceptorRegistry registry) {
         registry.addInterceptor(internalUserInterceptor)
                 .addPathPatterns(ALL_PATHS)
-                .excludePathPatterns(HEALTH_CHECK_PATH);
+                .excludePathPatterns(managementBasePath + healthCheckPathSuffix);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/authcodenotification/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/authcodenotification/config/InterceptorConfig.java
@@ -1,0 +1,32 @@
+package uk.gov.companieshouse.authcodenotification.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.lang.NonNull;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
+
+@Configuration
+@ComponentScan("uk.gov.companieshouse.api.interceptor")
+public class InterceptorConfig implements WebMvcConfigurer {
+
+    static final String ALL_PATHS = "/**";
+    static final String HEALTH_CHECK_PATH = "/auth-code-notification/healthcheck";
+
+    @Autowired
+    private InternalUserInterceptor internalUserInterceptor;
+
+    /**
+     * Set up the interceptors to run against endpoints when the endpoints are called
+     * Interceptors are executed in the order they are added to the registry
+     * @param registry The spring interceptor registry
+     */
+    @Override
+    public void addInterceptors(@NonNull InterceptorRegistry registry) {
+        registry.addInterceptor(internalUserInterceptor)
+                .addPathPatterns(ALL_PATHS)
+                .excludePathPatterns(HEALTH_CHECK_PATH);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/authcodenotification/config/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/authcodenotification/config/InterceptorConfigTest.java
@@ -1,0 +1,51 @@
+package uk.gov.companieshouse.authcodenotification.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InterceptorConfigTest {
+
+    @Mock
+    private InterceptorRegistry interceptorRegistry;
+
+    @Mock
+    private InterceptorRegistration interceptorRegistration;
+
+    @Mock
+    private InternalUserInterceptor internalUserInterceptor;
+
+    @InjectMocks
+    private InterceptorConfig interceptorConfig;
+
+    @Test
+    void addInterceptorsTest() {
+        when(interceptorRegistry.addInterceptor(any())).thenReturn(interceptorRegistration);
+        when(interceptorRegistration.addPathPatterns(any(String.class))).thenReturn(interceptorRegistration);
+        when(interceptorRegistration.excludePathPatterns(any(String.class))).thenReturn(interceptorRegistration);
+
+        interceptorConfig.addInterceptors(interceptorRegistry);
+
+        //  The order that the interceptors are added is important, they get executed in the order they are added,
+        //  i.e. first interceptor added gets run first.
+        //  This test will ensure that the interceptors are added in the correct order in InterceptorConfig
+
+        InOrder inOrder = inOrder(interceptorRegistry, interceptorRegistration);
+
+        // Internal User authentication interceptor check
+        inOrder.verify(interceptorRegistry).addInterceptor(internalUserInterceptor);
+        inOrder.verify(interceptorRegistration).addPathPatterns(InterceptorConfig.ALL_PATHS);
+        inOrder.verify(interceptorRegistration).excludePathPatterns(InterceptorConfig.HEALTH_CHECK_PATH);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/authcodenotification/config/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/authcodenotification/config/InterceptorConfigTest.java
@@ -17,6 +17,9 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class InterceptorConfigTest {
 
+    private static final String ALL_PATHS = "/**";
+    private static final String HEALTH_CHECK_PATH = "/**/healthcheck";
+
     @Mock
     private InterceptorRegistry interceptorRegistry;
 
@@ -45,7 +48,7 @@ class InterceptorConfigTest {
 
         // Internal User authentication interceptor check
         inOrder.verify(interceptorRegistry).addInterceptor(internalUserInterceptor);
-        inOrder.verify(interceptorRegistration).addPathPatterns(InterceptorConfig.ALL_PATHS);
-        inOrder.verify(interceptorRegistration).excludePathPatterns(InterceptorConfig.HEALTH_CHECK_PATH);
+        inOrder.verify(interceptorRegistration).addPathPatterns(ALL_PATHS);
+        inOrder.verify(interceptorRegistration).excludePathPatterns(HEALTH_CHECK_PATH);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/authcodenotification/config/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/authcodenotification/config/InterceptorConfigTest.java
@@ -1,11 +1,13 @@
 package uk.gov.companieshouse.authcodenotification.config;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
@@ -18,7 +20,9 @@ import static org.mockito.Mockito.when;
 class InterceptorConfigTest {
 
     private static final String ALL_PATHS = "/**";
-    private static final String HEALTH_CHECK_PATH = "/**/healthcheck";
+    private static final String MANAGEMENT_BASE_PATH = "/auth-code-notification/";
+    private static final String HEALTH_CHECK_PATH_SUFFIX = "healthcheck";
+    private static final String HEALTH_CHECK_PATH = MANAGEMENT_BASE_PATH + HEALTH_CHECK_PATH_SUFFIX;
 
     @Mock
     private InterceptorRegistry interceptorRegistry;
@@ -31,6 +35,12 @@ class InterceptorConfigTest {
 
     @InjectMocks
     private InterceptorConfig interceptorConfig;
+
+    @BeforeEach
+    void init() {
+        ReflectionTestUtils.setField(interceptorConfig, "managementBasePath", MANAGEMENT_BASE_PATH);
+        ReflectionTestUtils.setField(interceptorConfig, "healthCheckPathSuffix", HEALTH_CHECK_PATH_SUFFIX);
+    }
 
     @Test
     void addInterceptorsTest() {


### PR DESCRIPTION
…llow internal api key requests

### JIRA link
https://companieshouse.atlassian.net/browse/ROE-2234


### Change description
Adding the InternalUserInterceptor to only allow access to endpoints (excluding healthcheck) using an internal api key.


### Work checklist

- [ ] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
