### PR TITLE
ROE-2224 Changing use of SecureRandom to use non blocking /dev/urando…

### DIFF
--- a/src/main/java/uk/gov/companieshouse/authcodenotification/utils/Encrypter.java
+++ b/src/main/java/uk/gov/companieshouse/authcodenotification/utils/Encrypter.java
@@ -39,7 +39,7 @@ public class Encrypter {
 
             // AES in CBC mode requires any initialisation vector (IV) which should be random for each encryption.
             // use a cryptographically strong random generator to generate the data for this IV
-            var random = SecureRandom.getInstanceStrong();
+            var random = new SecureRandom();
             var initialisationVector = new byte[Cipher.getInstance(AES_CBC_PKCS_5_PADDING).getBlockSize()];
             random.nextBytes(initialisationVector);
 


### PR DESCRIPTION
…m instead of the thread blocking /dev/random

### JIRA link
https://companieshouse.atlassian.net/browse/ROE-2224


### Change description
Changing from using SecureRandom.getInstanceStrong() to new SecureRandom() as previous usage was causing thread blocking in test environments and new approach should not block and should be as secure. Changes based on this article - https://tersesystems.com/blog/2015/12/17/the-right-way-to-use-securerandom/


### Work checklist

- [ ] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
