### PR TITLE
ROE-2297 Address Concourse security vulnerability on Commons-BeanUtils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
     <structured-logging.version>1.9.19</structured-logging.version>
-    <api-sdk-manager-java-library.version>1.0.7</api-sdk-manager-java-library.version>
+    <api-sdk-manager-java-library.version>1.0.8</api-sdk-manager-java-library.version>
     <json.version>20230618</json.version>
     <api-sdk-java.version>4.3.31</api-sdk-java.version>
     <private-api-sdk-java.version>2.0.270</private-api-sdk-java.version>


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-2297

### Change description

Upgrade api-sdk-manager-java-library to bump up version of commons-beanutils to 1.9.4. This addresses security issue - https://github.com/advisories/GHSA-6phf-73q6-gh87 - https://commons.apache.org/proper/commons-beanutils/ 
identified by the security-check on Concourse.

### Work checklist

- [ ] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
