### PR TITLE
Use parent pom for depdency-check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>uk.gov.companieshouse</groupId>
     <artifactId>companies-house-parent</artifactId>
-    <version>1.3.1</version> <!-- lookup parent from repository -->
+    <version>2.1.4</version> <!-- lookup parent from repository -->
   </parent>
   <artifactId>auth-code-notification</artifactId>
   <version>unversioned</version>
@@ -28,7 +28,6 @@
     <encoder.version>1.2.3</encoder.version>
     <rest-service-common-library-version>0.0.8</rest-service-common-library-version>
     <api-security-java.version>0.4.1</api-security-java.version>
-    <dependency-check-plugin.version>8.3.1</dependency-check-plugin.version>
   </properties>
   <profiles>
     <profile>
@@ -192,23 +191,6 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.owasp</groupId>
-        <artifactId>dependency-check-maven</artifactId>
-        <version>${dependency-check-plugin.version}</version>
-        <configuration>
-          <suppressionFiles>
-            <suppressionFile>suppress.xml</suppressionFile>
-          </suppressionFiles>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Cache results of previous builds per advice (https://github.com/jeremylong/DependencyCheck?tab=readme-ov-file#the-nvd-api-key-ci-and-rate-limiting)

Use parent pom to retrieve version and key for nvd api check rather than data feed.


### Work checklist

- [ ] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
