### PR TITLE
ASM-625: Dependency CVE fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,18 +38,18 @@
     <opentelemetry-instrumentation.version>2.25.0</opentelemetry-instrumentation.version>
 
     <!-- Spring Boot -->
-    <spring-boot-dependencies.version>4.0.3</spring-boot-dependencies.version>
+    <spring-boot-dependencies.version>4.0.6</spring-boot-dependencies.version>
 
     <avro.version>1.12.1</avro.version>
     <json.version>20251224</json.version>
     <grpc.version>1.78.0</grpc.version>
     <okhttp.version>5.3.2</okhttp.version>
-    <tomcat.version>11.0.18</tomcat.version>
+    <tomcat.version>11.0.22</tomcat.version>
     <encoder.version>1.4.0</encoder.version>
-    <jackson.version>3.1.0</jackson.version>
+    <jackson.version>3.1.1</jackson.version>
 
     <!-- Force version of kafka for compatibility with ch-kafka -->
-    <kafka-clients.version>3.9.1</kafka-clients.version>
+    <kafka-clients.version>3.9.2</kafka-clients.version>
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
     <mockito-core.version>5.21.0</mockito-core.version>
@@ -123,6 +123,13 @@
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-stdlib</artifactId>
         <version>2.2.21</version>
+      </dependency>
+
+      <!-- CVE-2025-67030 - transitive (test scope) via sonar-maven-plugin -->
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.6.1</version>
       </dependency>
 
     </dependencies>
@@ -214,6 +221,11 @@
         <exclusion>
           <groupId>commons-lang</groupId>
           <artifactId>commons-lang</artifactId>
+        </exclusion>
+        <!-- org.lz4:lz4-java is abandoned at 1.8.0; replaced by at.yawk.lz4 fork below -->
+        <exclusion>
+          <groupId>org.lz4</groupId>
+          <artifactId>lz4-java</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -307,6 +319,14 @@
       <artifactId>log4j-api</artifactId>
       <version>2.25.3</version>
       <scope>compile</scope>
+    </dependency>
+
+    <!-- CVE-2025-12183, CVE-2025-66566 - upstream org.lz4:lz4-java abandoned at 1.8.0; community fork -->
+    <dependency>
+      <groupId>at.yawk.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
+      <version>1.10.2</version>
+      <scope>runtime</scope>
     </dependency>
 
     <!--end transitive dependencies-->

--- a/pom.xml
+++ b/pom.xml
@@ -313,11 +313,11 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- override log4j-api to fix CVE-2025-68161 - transitive dependency from private-api-sdk-java 4.0.450 -->
+    <!-- override log4j-api to fix CVE-2025-68161, CVE-2026-34477, CVE-2026-34479 - transitive dependency from private-api-sdk-java 4.0.450 -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.25.3</version>
+      <version>2.25.4</version>
       <scope>compile</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <maven-surefire.version>3.5.2</maven-surefire.version>
     <maven-surefire-plugin.version>${maven-surefire.version}</maven-surefire-plugin.version>
     <maven-failsafe-plugin.version>${maven-surefire.version}</maven-failsafe-plugin.version>
-    <spring-boot-maven-plugin.version>3.5.7</spring-boot-maven-plugin.version>
+    <spring-boot-maven-plugin.version>4.0.6</spring-boot-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>
     <opentelemetry-instrumentation.version>2.25.0</opentelemetry-instrumentation.version>


### PR DESCRIPTION
### JIRA link

[ASM-625](https://companieshouse.atlassian.net/browse/ASM-625)

### Change description

Bumps dependencies to clear the May 2026 CVE batch raised against this service on Dependency Track. Scope is intentionally narrow: version bumps + transitive overrides only, no source changes.

**Direct version bumps (`pom.xml`):**

| Property | Was | Now |
| --- | --- | --- |
| `spring-boot-dependencies.version` | 4.0.3 | 4.0.6 |
| `spring-boot-maven-plugin.version` | 3.5.7 | 4.0.6 |
| `tomcat.version` | 11.0.18 | 11.0.22 |
| `jackson.version` | 3.1.0 | 3.1.1 |
| `kafka-clients.version` | 3.9.1 | 3.9.2 |
| `log4j-api` override | 2.25.3 | 2.25.4 |

**Transitive overrides:**

- `plexus-utils` 3.4.1 → 3.6.1 via `<dependencyManagement>` (test scope, pulled in by `sonar-maven-plugin`).
- `org.lz4:lz4-java` 1.8.0 is **abandoned upstream** (last release 1.8.0). Excluded from the `ch-kafka` dependency and replaced with the community fork `at.yawk.lz4:lz4-java:1.10.2` (Sonatype redirects the original coordinate to the fork; drop-in API compatible).

**CVE coverage (28 findings cleared):**

| Artifact | CVE / GHSA | Severity | Cleared by |
| --- | --- | --- | --- |
| `tomcat-embed-core` | CVE-2026-29145 | Critical | tomcat 11.0.22 |
| `tomcat-embed-core` | GHSA-95jq-rwvf-vjx4 | Critical | tomcat 11.0.22 |
| `tomcat-embed-core` | CVE-2026-29129 | High | tomcat 11.0.22 |
| `tomcat-embed-core` | CVE-2026-34483 | High | tomcat 11.0.22 |
| `tomcat-embed-core` | GHSA-rv64-5gf8-9qq8 | High | tomcat 11.0.22 |
| `tomcat-embed-core` | GHSA-x4m4-345f-5h5g | High | tomcat 11.0.22 |
| `tomcat-embed-core` | GHSA-69cc-cv78-qc8g | High | tomcat 11.0.22 |
| `spring-boot-autoconfigure` | CVE-2026-40971 | Critical | Spring Boot 4.0.6 |
| `spring-boot` | GHSA-8v8j-3hxp-93wr | Critical | Spring Boot 4.0.6 |
| `spring-boot` | CVE-2026-40975 | High | Spring Boot 4.0.6 |
| `spring-boot` | CVE-2026-40973 | High | Spring Boot 4.0.6 |
| `spring-boot` | GHSA-wwpq-f5c3-7hvx | High | Spring Boot 4.0.6 |
| `spring-boot-actuator` | CVE-2026-22731 | High | Spring Boot 4.0.6 |
| `spring-boot-starter-actuator` | GHSA-mgvc-8q2h-5pgc | High | Spring Boot 4.0.6 |
| `spring-boot-starter-actuator` | GHSA-8hfc-fq58-r658 | High | Spring Boot 4.0.6 |
| `jackson-core` | GHSA-2m67-wjpj-xhg9 | High | jackson 3.1.1 |
| `kafka-clients` | CVE-2026-35554 | High | kafka-clients 3.9.2 |
| `kafka-clients` | GHSA-5qcv-4rpc-jp93 | High | kafka-clients 3.9.2 |
| `lz4-java` | CVE-2025-12183 | High | at.yawk.lz4 fork 1.10.2 |
| `lz4-java` | CVE-2025-66566 | High | at.yawk.lz4 fork 1.10.2 |
| `lz4-java` | GHSA-cmp6-m4wj-q63q | High | at.yawk.lz4 fork 1.10.2 |
| `lz4-java` | GHSA-vqf4-7m7x-wgfc | High | at.yawk.lz4 fork 1.10.2 |
| `plexus-utils` | CVE-2025-67030 | High | plexus-utils 3.6.1 |
| `plexus-utils` | GHSA-6fmv-xxpf-w3cw | High | plexus-utils 3.6.1 |
| `log4j-api` | CVE-2026-34477 | Medium | log4j-api 2.25.4 |
| `log4j-api` | CVE-2026-34479 | Medium | log4j-api 2.25.4 |

### Work checklist

- [x] Tests added where applicable — none required; pom-only change, full suite (75 tests) green locally.

### Notes to the tester

- `mvn clean verify` is green (75 unit tests pass, no IT changes).
- `mvn dependency:tree` confirms: `at.yawk.lz4:lz4-java:1.10.2` is present, `org.lz4:lz4-java` is gone, `plexus-utils:3.6.1`, `tomcat-embed-core:11.0.22`, `spring-boot:4.0.6`, `jackson-core:3.1.1`, `kafka-clients:3.9.2`, `log4j-api:2.25.4`.
- Verified locally via `docker-chs-development`: service comes up healthy on Spring Boot 4.0.6 / Tomcat 11.0.22, healthcheck returns 200.


[ASM-625]: https://companieshouse.atlassian.net/browse/ASM-625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ